### PR TITLE
feat: replace Geist fonts with Aleo font family

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-aleo);
+  --font-mono: var(--font-aleo);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-aleo), Arial, Helvetica, sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Aleo } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const aleo = Aleo({
+  variable: "--font-aleo",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: ["300", "400", "700"],
 });
 
 export const metadata: Metadata = {
@@ -25,7 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${aleo.variable} antialiased`}
       >
         {children}
       </body>


### PR DESCRIPTION
- Import Aleo font from Google Fonts with weights 300, 400, 700
- Update layout.tsx to use Aleo instead of Geist and Geist_Mono
- Configure CSS variables to use Aleo for both sans and mono fonts
- Apply Aleo font to body element with proper fallbacks
- Improve typography consistency across the application

This change enhances the visual design by using a more distinctive serif font that better fits the restaurant/food theme of the application.